### PR TITLE
将config的初始化在CreateAPP时执行，并且可以传入初始化好的conf来自由载入conf

### DIFF
--- a/module/module.go
+++ b/module/module.go
@@ -32,7 +32,7 @@ type ServerSession interface {
 	CallNRArgs(_func string, ArgsType []string, args [][]byte) (err error)
 }
 type App interface {
-	Run(debug bool, mods ...Module) error
+	Run(mods ...Module) error
 	/**
 	当同一个类型的Module存在多个服务时,需要根据情况选择最终路由到哪一个服务去
 	fn: func(moduleType string,serverId string,[]*ServerSession)(*ServerSession)

--- a/mqant.go
+++ b/mqant.go
@@ -16,6 +16,7 @@ package mqant
 import "github.com/liangdas/mqant/module"
 import "github.com/liangdas/mqant/app"
 
-func CreateApp() module.App {
-	return defaultApp.NewApp(Version)
+// CreateApp 构建mqant应用实例
+func CreateApp(debug bool, options ...interface{}) module.App {
+	return defaultApp.NewApp(Version, debug, options...)
 }


### PR DESCRIPTION
修改了App的初始化逻辑：

原来：app的setting是在Run方法执行时载入的，通过conf的LoadConfig方法
现在：app的setting是在Create时载入的，并且可以传入已经load好的conf.Config对象，来跳过从硬盘读取

影响：
为了提前初始化conf，将参数debug也一并移动到了CreateAPP方法中，所以原来在run时才传的debug参数现在要移到CreateAPP的时候传入

CreateAPP的参数除了debug，还可以传入其他选项，当前实现了传入conf.Config对象，可以直接以此作为setting来创建app：
``` golang
func NewApp(version string, debug bool, options ...interface{}) module.App {
...
	var (
		optConf *conf.Config
	)
	for _, option := range options {
		switch o := option.(type) {
		case conf.Config:
			optConf = &o
		default:
			panic(option)
		}
	}
...
}
```
以这种方式传入options可以使app变得更为灵活

例如，以后可以把logger也作为一个实例化好的对象直接传入（入未传入则使用默认的），然后app内部需要log时直接调用```app.logger.Debug("something")```这样，可以进一步解耦，我们只需要定一个log Interface，这样可以很方便的对接到三方logger方案并且非常优雅

望采纳

希望mqant越加强大