### PR TITLE
support windows

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -141,7 +141,7 @@ func (app *DefaultApp) Run(debug bool, mods ...module.Module) error {
 
 	}
 	app.workDir = ApplicationDir
-	defaultConfPath := fmt.Sprintf("/%s/bin/conf/server.json", ApplicationDir)
+	defaultConfPath := fmt.Sprintf("%s/bin/conf/server.json", ApplicationDir)
 	defaultLogPath := fmt.Sprintf("%s/bin/logs", ApplicationDir)
 	defaultBIPath := fmt.Sprintf("%s/bin/bi", ApplicationDir)
 


### PR DESCRIPTION
master分支
去掉这一个“/”后，windows就能正确的读到配置文件了，linux也能去读到配置文件
很丢人的pr了……