### PR TITLE
feat: 修复文件打开后未关闭的bug

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -110,7 +110,7 @@ func newOptions(opts ...module.Option) module.Options {
 	}
 	ApplicationDir := ""
 	if opt.WorkDir != "" {
-		_, err := os.Open(opt.WorkDir)
+		_, err := os.Stat(opt.WorkDir)
 		if err != nil {
 			panic(err)
 		}
@@ -155,28 +155,25 @@ func newOptions(opts ...module.Option) module.Options {
 		}
 	}
 
-	_, err := os.Open(opt.ConfPath)
-	if err != nil {
+	if _, err := os.Stat(opt.ConfPath); err != nil {
 		//文件不存在
 		panic(fmt.Sprintf("config path error %v", err))
 	}
-	_, err = os.Open(opt.LogDir)
-	if err != nil {
+	if _, err := os.Stat(opt.LogDir); err != nil {
 		//文件不存在
-		err := os.Mkdir(opt.LogDir, os.ModePerm) //
+		err := os.Mkdir(opt.LogDir, os.ModePerm)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}
+	if _, err := os.Stat(opt.BIDir); err != nil {
+		//文件不存在
+		err := os.Mkdir(opt.BIDir, os.ModePerm)
 		if err != nil {
 			fmt.Println(err)
 		}
 	}
 
-	_, err = os.Open(opt.BIDir)
-	if err != nil {
-		//文件不存在
-		err := os.Mkdir(opt.BIDir, os.ModePerm) //
-		if err != nil {
-			fmt.Println(err)
-		}
-	}
 	return opt
 }
 
@@ -209,14 +206,13 @@ type DefaultApp struct {
 
 // Run 运行应用
 func (app *DefaultApp) Run(mods ...module.Module) error {
-	f, err := os.Open(app.opts.ConfPath)
-	if err != nil {
+	if _, err := os.Stat(app.opts.ConfPath); err != nil {
 		//文件不存在
 		panic(fmt.Sprintf("config path error %v", err))
 	}
 	var cof conf.Config
 	fmt.Println("Server configuration path :", app.opts.ConfPath)
-	conf.LoadConfig(f.Name()) //加载配置文件
+	conf.LoadConfig(app.opts.ConfPath) //加载配置文件
 	cof = conf.Conf
 	app.Configure(cof) //解析配置信息
 


### PR DESCRIPTION
1、配置初始化时部分文件描述符打开后未关闭，修复方案：使用Stat替换Open方法，用于检测文件或目录是否存在